### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 - 发表作品
 
 
-##下载
+## 下载
 [小米应用市场](http://app.xiaomi.com/detail/420500)
 
-##截图
+## 截图
 ![主页](https://github.com/gatsbydhn/Peanut/blob/master/image/shot1.png)
 ![登陆](https://github.com/gatsbydhn/Peanut/blob/master/image/shot2.png)
 ![喜爱页](https://github.com/gatsbydhn/Peanut/blob/master/image/shot4.png)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
